### PR TITLE
Extended rollup config to additionally generate a UMD bundle.

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,11 +3,16 @@ import {terser} from "rollup-plugin-terser";
 
 export default {
     input: './index.js',
-    output: {
+    output: [{
         file: './dist/xeokit-bim-viewer.es.js',
         format: 'es',
         name: 'bundle'
     },
+    {
+        file: './dist/xeokit-bim-viewer.umd.js',
+        format: 'umd',
+        name: 'bundle'
+    }],
     plugins: [
         nodeResolve(),
          terser()


### PR DESCRIPTION
rollup.conf has beed extended to include a creation of an additional umd bundle.