### PR TITLE
FEATURE: More vibrant default Selection and Highlight materials

### DIFF
--- a/src/BIMViewer.js
+++ b/src/BIMViewer.js
@@ -551,11 +551,18 @@ class BIMViewer extends Controller {
         scene.xrayMaterial.edgeColor = [0, 0, 0];
 
         scene.highlightMaterial.edges = true;
-        scene.highlightMaterial.edgeColor = [1, 1, 0];
-        scene.highlightMaterial.edgeAlpha = 0.9;
+        scene.highlightMaterial.edgeColor = [1, 1, 1];
+        scene.highlightMaterial.edgeAlpha = 1.0;
         scene.highlightMaterial.fill = true;
         scene.highlightMaterial.fillAlpha = 0.1;
         scene.highlightMaterial.fillColor = [1, 0, 0];
+
+        scene.selectedMaterial.edges = true;
+        scene.selectedMaterial.edgeColor = [1, 1, 1];
+        scene.selectedMaterial.edgeAlpha = 1.0;
+        scene.selectedMaterial.fill = true;
+        scene.selectedMaterial.fillAlpha = 0.1;
+        scene.selectedMaterial.fillColor = [0, 1, 0];
 
         //------------------------------------------------------------------------------------------------------------------
         // Configure points material


### PR DESCRIPTION
Make the edges of default Selection and highlight materials white, so they have more visual pop. 

![Screenshot from 2023-11-20 20-08-42](https://github.com/xeokit/xeokit-sdk/assets/83100/bfde6820-8a1b-4112-905a-55fff7fd27eb)

![Screenshot from 2023-11-20 20-12-48](https://github.com/xeokit/xeokit-sdk/assets/83100/0027e7d9-2482-4a9c-abee-562002b88cd4)