### PR TITLE
Bump xeokit-sdk to 2.6.0-beta-5

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "rollup-plugin-terser": "^7.0.2"
   },
   "dependencies": {
-    "@xeokit/xeokit-sdk": "^2.6.0-beta-4",
+    "@xeokit/xeokit-sdk": "^2.6.0-beta-5",
     "http-server": "^13.0.2"
   }
 }


### PR DESCRIPTION
Bump xeokit-sdk, to use this fix: https://github.com/xeokit/xeokit-sdk/releases/tag/v2.6.0-beta-5