### PR TITLE
xeokit-sdk fix: Add selection glowThrough support to DTX triangles renderer layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xeokit/xeokit-bim-viewer",
-  "version": "2.5.1-beta-22",
+  "version": "2.5.1-beta-23",
   "description": "BIM viewer built on xeokit",
   "main": "dist/xeokit-bim-viewer.min.es.js",
   "files": [
@@ -50,7 +50,7 @@
     "rollup-plugin-terser": "^7.0.2"
   },
   "dependencies": {
-    "@xeokit/xeokit-sdk": "^2.6.0-beta-7",
+    "@xeokit/xeokit-sdk": "^2.6.0-beta-8",
     "http-server": "^13.0.2"
   }
 }


### PR DESCRIPTION
Include xeokit-sdk fix for selection `glowThough` for `dtxEnabled` - details here: https://github.com/xeokit/xeokit-sdk/pull/1425 