### PR TITLE
[FIX] Fix bug where SectionPlanes are clipping DistanceMeasurements too coarsely

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@xeokit/xeokit-bim-viewer",
-  "version": "2.5.1-beta-22",
+  "version": "2.5.1-beta-25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xeokit/xeokit-bim-viewer",
-      "version": "2.5.1-beta-22",
+      "version": "2.5.1-beta-25",
       "license": "See LICENSE.txt",
       "dependencies": {
-        "@xeokit/xeokit-sdk": "^2.6.0-beta-7",
+        "@xeokit/xeokit-sdk": "^2.6.0-beta-10",
         "http-server": "^13.0.2"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xeokit/xeokit-bim-viewer",
-  "version": "2.5.1-beta-24",
+  "version": "2.5.1-beta-25",
   "description": "BIM viewer built on xeokit",
   "main": "dist/xeokit-bim-viewer.min.es.js",
   "files": [
@@ -50,7 +50,7 @@
     "rollup-plugin-terser": "^7.0.2"
   },
   "dependencies": {
-    "@xeokit/xeokit-sdk": "^2.6.0-beta-8",
+    "@xeokit/xeokit-sdk": "^2.6.0-beta-10",
     "http-server": "^13.0.2"
   }
 }


### PR DESCRIPTION
SectionPlanes clipping distance measurements too coarsely. 

A DistanceMeasurement is designed to become entirely invisible whenever either of its end points are clipped by a SectionPlane.

When clipping a SectionPlane, we are clipping the end points, but are also incorrectly clipping the intermediate points that are used when showing the X,Y,Z axis.

For some cases, this has the undesirable effect of causing DistanceMeasurements to be clipped when a SectionPlane is actually far away from the end points.

[Screencast from 01.04.2024 18:08:42.webm](https://github.com/xeokit/xeokit-sdk/assets/83100/6cf70f43-57fa-494d-9a00-c25b8e1d0930)
