### PR TITLE
improved section (slice) tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # .gitignore
+.vscode
 node_modules
+dist

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "liveServer.settings.port": 5501
-}


### PR DESCRIPTION
Existing section (slice) tool mistakenly read the mouse-up event from view spinning to create a new section pane.  This pull fix this in src\toolbar\SectionTool.js 